### PR TITLE
Add governance bot and sync labels across public repos

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,0 +1,25 @@
+---
+name: Community Documentation
+---
+
+<!-- Make sure to check for I have check for similar open and closed issue (see https://github.com/carbonaut-cloud/community/issues)-->
+
+### What is needed
+
+<!-- In addition to explaining your issue, please also provide a "kind" of label
+
+/kind feature
+/kind doc
+/kind bug
+/kind bug-fix
+/kind governance
+/kind clean-up
+-->
+
+### Why it is needed
+
+
+
+### Comments
+
+<!-- Make sure to check for I have check for similar open and closed issue (see https://github.com/carbonaut-cloud/community/issues) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,8 @@ What types of changes does your code introduce to Carbonaut?
 /kind bug-fix
 /kind governance
 /kind clean-up
+
+If multiple apply elaborate why multiple labels apply, thank you!
 -->
 
 
@@ -40,6 +42,8 @@ or
 <!-- 
 Please don't hesitate to use this section! 
 It is often a good idea to reference other issues, provide context or elaborate other options you explored...
+
+You can ask for reviews with /cc <github username>
 -->
 
 `None`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Proposed changes
+
+<!-- 
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. 
+-->
+
+## Types of changes
+
+What types of changes does your code introduce to Carbonaut?
+
+<!--
+/kind feature
+/kind doc
+/kind bug
+/kind bug-fix
+/kind governance
+/kind clean-up
+-->
+
+
+## Checklist
+
+<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask :). This is simply a reminder of what we are going to look for before merging code. -->
+
+_All boxes should be checked before the PR gets merged_
+- [ ] I have read the [CONTRIBUTING](https://github.com/carbonaut-cloud/community/blob/main/CONTRIBUTING.md) doc
+- [ ] I don't have a merge commit in my history (see [git merge documentation](https://www.git-scm.com/docs/git-merge#_options)) (if applicable)
+- [ ] I signed all my commits (see [how to sign commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))
+
+#### Which issue(s) this PR fixes:
+
+Fixes #
+
+or
+
+`None`
+
+## Comments
+
+<!-- 
+Please don't hesitate to use this section! 
+It is often a good idea to reference other issues, provide context or elaborate other options you explored...
+-->
+
+`None`

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -1,0 +1,144 @@
+version: v1
+
+#
+# ISSUE COMMANDS
+#
+issue:
+  labels:
+    - prefix: triage
+      list: [ "accepted" ]
+      multiple: false
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+      needs:
+        comment: |
+          @$AUTHOR: This issue is currently awaiting triage.
+
+          The triage/accepted label can be added by org members by writing `/triage accepted` in a comment.
+
+    - prefix: kind
+      list: [ "feature", "doc", "bug-fix", "governance", "clean-up", "epic" ]
+      needs:
+        comment: |
+          @$AUTHOR: There are no 'kind' label on this issue. Please specify a 'kind' label, thank you!
+
+          * `/kind feature`
+          * `/kind doc`
+          * `/kind bug`
+          * `/kind bug-fix`
+          * `/kind governance`
+          * `/kind clean-up`
+          * `/kind epic`
+
+    - prefix: priority
+      multiple: false
+      list: [ "critical-urgent", "urgent", "important-soon", "long-term" ]
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+
+    - prefix: warning
+      list: [ "breaking-change" ]
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+      needs:
+        status:
+          context: "Warning"
+          description:
+            success: |
+              @carbonaut-cloud/maintainers a warning label has been added to the issue
+
+  chat_ops:
+    - cmd: /close
+      type: close
+      author_association:
+        author: true
+        collaborator: true
+        member: true
+        owner: true
+
+    - cmd: /cc
+      type: none # does not trigger anything
+
+    - cmd: /assign
+      type: assign
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+
+    - cmd: /help
+      type: label
+      label:
+        add: help wanted
+
+    - cmd: /duplicate
+      type: label
+      label:
+        add: duplicate
+
+#
+# PULL REQUEST COMMANDS
+#
+pull_request:
+  labels:
+    - prefix: kind
+      list: [ "feature", "doc", "bug-fix", "governance", "clean-up" ]
+      multiple: false
+      needs:
+        comment: |
+          @$AUTHOR: There are no 'kind' label on this PR. Please specify a 'kind' label, thank you!
+
+          * `/kind feature`
+          * `/kind doc`
+          * `/kind bug`
+          * `/kind bug-fix`
+          * `/kind governance`
+          * `/kind clean-up`
+
+    - prefix: priority
+      multiple: false
+      list: [ "critical-urgent", "urgent", "important-soon", "long-term" ]
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+
+  chat_ops:
+    - cmd: /close
+      type: close
+      author_association:
+        author: true
+        collaborator: true
+        member: true
+        owner: true
+
+    - cmd: /cc
+      type: review
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+
+    - cmd: /assign
+      type: assign
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+
+    - cmd: /lgtm
+      type: label
+      label:
+        add: /lgtm
+
+    - cmd: /hold
+      type: label
+      label:
+        add: hold/do-not-merge
+        remove: [ 'lgtm' ]

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -109,6 +109,14 @@ pull_request:
         member: true
         owner: true
 
+    - prefix: merge
+      multiple: false
+      list: [ "squash", "rebase" ]
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+
   chat_ops:
     - cmd: /close
       type: close
@@ -136,6 +144,7 @@ pull_request:
       type: label
       label:
         add: /lgtm
+
 
     - cmd: /hold
       type: label

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -43,6 +43,9 @@
 - color: cc40d8
   name: merge/squash
   description: Merge method squash
+- color: cc40d8
+  name: merge/rebase
+  description: Merge method rebase, which is also the default
 
 # Kind
 - color: 3410B8

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,6 +2,9 @@
 - color: c4d471
   name: duplicate
   description: This issue or pull request already exists
+- color: D4C5F9
+  name: dependencies
+  description: Pull requests that update a dependency file
 - color: 006B75
   name: help wanted
   description: Extra attention is needed
@@ -19,6 +22,11 @@
 - color: D93F0B
   name: hold/do-not-merge
   description: Do not merge! - label bots are looking out for
+
+# Warning labels
+- color: B60205
+  name: warning/breaking-change
+  description: Changes made will not be compatible with prior versions - A major breaking change is marked
 
 # Needs
 - color: cc40d8
@@ -39,7 +47,7 @@
 # Kind
 - color: 3410B8
   name: kind/epic
-  description: EPIC / Tracking issue that is used to bundle a larger effort
+  description: Used for issues tracking a larger effort
 - color: B60205
   name: kind/bug
   description: Something isn't working
@@ -50,23 +58,14 @@
   name: kind/feature
   description: New feature request
 - color: e7e9eb
-  name: kind/question
-  description: Generic question
-- color: e7e9eb
   name: kind/governance
   description: Non feature change that makes governance changes 
 - color: 0075ca
   name: kind/docs
   description: Non feature documentation change
 - color: e7e9eb
-  name: kind/refactor
-  description: Non feature refactor change
-- color: B60205
-  name: kind/breaking-change
-  description: Changes made will not be compatible with prior versions - A major breaking change is marked
-- color: e7e9eb
-  name: kind/dependencies
-  description: Pull requests that update a dependency file
+  name: kind/clean-up
+  description: Refactoring with no feature changes
 
 # Priority
 - color: B60205

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,24 @@
+on:
+  pull_request_target:
+    types: [ synchronize, opened, labeled, unlabeled ]
+  issues:
+    types: [ opened, labeled, unlabeled ]
+  issue_comment:
+    types: [ created ]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: write
+  checks: write
+
+jobs:
+  governance:
+    name: Governance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: carbonaut-cloud/carbonaut-governance-bot@v2.0.11
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          config-path: .github/governance.yml

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -12,5 +12,26 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: micnncim/action-label-syncer@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_LABEL_SYNC }}
+        with:
+          manifest: .github/labels.yml
+          repository: |
+              carbonaut-cloud/community
+          token: ${{ secrets.GH_LABEL_TOKEN }}
+      - uses: micnncim/action-label-syncer@v1
+        with:
+          manifest: .github/labels.yml
+          repository: |
+              carbonaut-cloud/carbonaut
+          token: ${{ secrets.GH_LABEL_TOKEN }}
+      - uses: micnncim/action-label-syncer@v1
+        with:
+          manifest: .github/labels.yml
+          repository: |
+              carbonaut-cloud/carbonaut-governance-bot
+          token: ${{ secrets.GH_LABEL_TOKEN }}
+      - uses: micnncim/action-label-syncer@v1
+        with:
+          manifest: .github/labels.yml
+          repository: |
+              carbonaut-cloud/carbonaut-cloud.github.io
+          token: ${{ secrets.GH_LABEL_TOKEN }}


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

The label sync now updates the labels for all public repos

The governance bot (see [forked repo](https://github.com/carbonaut-cloud/carbonaut-governance-bot)) enables using various slash commands

ref tracking issue: https://github.com/carbonaut-cloud/community/issues/27